### PR TITLE
Added Docker and CI/CD

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,28 @@
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == "push"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: docker build . --tag bolang
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin 
+      - name: Push image to GitHub Container Registry
+        run: | 
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          IMAGE_ID=$(echo $IMAGE_ID | tr "[A-Z]" "[a-z]")
+          VERSION=$(echo "${{ github.ref }}" | sed -e "s,.*/\(.*\),\1,")
+          [[ "${{ github.ref }}" == "refs/tags/*" ]] && VERSION=$(echo $VERSION | sed -e "s/^v//")
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+RUN apt-get update -y 
+RUN apt-get install -y cabal-install libgc-dev ghc llvm-9-dev zlib1g-dev g++ 
+RUN cabal update
+RUN cabal install cabal-install
+RUN cabal install happy alex llvm-hs llvm-hs-pure split HUnit
+ADD . /bin/bolang
+WORKDIR /bin/bolang
+RUN cabal run test
+RUN cabal build 
+RUN mv /bin/bolang/dist/build/bolang/bolang /usr/local/bin   
+WORKDIR /home
+ENTRYPOINT ["bolang"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM ubuntu:latest
-RUN apt-get update -y 
-RUN apt-get install -y cabal-install libgc-dev ghc llvm-9-dev zlib1g-dev g++ 
+FROM debian:bullseye
+RUN apt-get update -y
+RUN apt-get install -y cabal-install libgc-dev ghc llvm-9-dev zlib1g-dev g++
 RUN cabal update
 RUN cabal install cabal-install
-RUN cabal install happy alex llvm-hs llvm-hs-pure split HUnit
-ADD . /bin/bolang
-WORKDIR /bin/bolang
-RUN cabal run test
-RUN cabal build 
-RUN mv /bin/bolang/dist/build/bolang/bolang /usr/local/bin   
+RUN cabal install happy alex llvm-hs llvm-hs-pure HUnit language-c temporary
+ADD . /home
 WORKDIR /home
-ENTRYPOINT ["bolang"] 
+RUN cabal install --installdir=/usr/local/bin
+ENTRYPOINT ["bolang"]


### PR DESCRIPTION
Hi Tadeusz, I finally achieved a production-ready Bolang Dockerfile. Also, I made CI/CD to automate pushing a new build of Bolang's image on push event on the master branch in your repository. All you have to do is to generate a GitHub token and pass it into GitHub secrets. All environmental variables should be descriptive in code. When you meet some troubles, let me know.  To run Bolang interpreter, you have to type: 

```sh
docker run -it ghcr.io/tadeuszjt/bolang:latest
```

or simply `bolang:latest` in the case when you will build that image on your own or push it to docker hub.

To compile anything without getting into an interpreter, you don't need to pass `-it` flag.

Command to build Bolang in the Docker locally:

```sh
docker build -t bolang .
```

Greetings from Paweł, and my co-worker @KrzysztofZawisla